### PR TITLE
Ignore ".colorset"

### DIFF
--- a/Shark.swift
+++ b/Shark.swift
@@ -37,7 +37,7 @@ struct EnumBuilder {
         return validSet.inverted
     }()
     
-    private static let forbiddenPathExtensions = [".appiconset/", ".launchimage/"]
+    private static let forbiddenPathExtensions = [".appiconset/", ".launchimage/", ".colorset/"]
     private static let imageSetExtension = "imageset"
     
     static func enumStringForPath(_ path: String, topLevelName: String = "Shark") throws -> String {


### PR DESCRIPTION
I have two colorsets: BackgroundColor and ForegroundColor

<img width="178" alt="screenshot 2018-09-04 at 17 46 38" src="https://user-images.githubusercontent.com/8875768/45042218-7f167400-b06a-11e8-9b26-56bfab0a9809.png">

If colorset is not ignored we have two useless enum in this case

 ```swift
  public enum NavigationBar: String, SharkImageConvertible {

        public enum ForegroundColorcolorset {
        }


        public enum BackgroundColorcolorset {
        }

            case next
            case previous
    }
```

the patch add ,".colorset/" to ignore list