### PR TITLE
Update XcodeProj dependency to 7.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {
           "branch": null,
-          "revision": "54bb8ea6fb693dd3f92a89e5fcc19e199fdeedd0",
-          "version": "4.3.3"
+          "revision": "e4d517844dd03dac557e35d77a8e9ab438de91a6",
+          "version": "4.4.0"
         }
       },
       {
@@ -15,8 +15,17 @@
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "Shell",
+        "repositoryURL": "https://github.com/tuist/Shell",
+        "state": {
+          "branch": null,
+          "revision": "d38121f89401db902b0d0bfc30b987e2c84c254e",
+          "version": "2.0.3"
         }
       },
       {
@@ -33,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": null,
-          "revision": "f1c9ad9a253cdf1aa89a7f5c99c30b4513b06ddb",
-          "version": "0.1.1"
+          "revision": "f73b84bc1525998e5e267f9d830c1411487ac65e",
+          "version": "0.2.0"
         }
       },
       {
@@ -42,26 +51,17 @@
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
           "branch": null,
-          "revision": "8656a25cb906c1896339f950ac960ee1b4fe8034",
-          "version": "0.4.0"
+          "revision": "9abcc2260438177cecd7cf5185b144d13e74122b",
+          "version": "0.5.0"
         }
       },
       {
-        "package": "SwiftShell",
-        "repositoryURL": "https://github.com/kareman/SwiftShell",
-        "state": {
-          "branch": null,
-          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
-          "version": "4.1.2"
-        }
-      },
-      {
-        "package": "xcodeproj",
+        "package": "XcodeProj",
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "065f348754b6155b8037dc43876a8f2ee354b95d",
-          "version": "6.7.0"
+          "revision": "aefcbf59cea5b0831837ed2f385e6dfd80d82cc9",
+          "version": "7.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,12 +7,12 @@ let package = Package(
     name: "Shark",
     dependencies: [
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
-        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMajor(from: "6.6.0")),
+        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMajor(from: "7.1.0")),
     ],
     targets: [
         .target(
             name: "Shark",
-            dependencies: ["SPMUtility", "xcodeproj"]),
+            dependencies: ["SPMUtility", "XcodeProj"]),
         .testTarget(
             name: "SharkTests",
             dependencies: ["Shark"]),

--- a/Sources/Shark/XcodeProjectHelper.swift
+++ b/Sources/Shark/XcodeProjectHelper.swift
@@ -1,5 +1,5 @@
 import Foundation
-import xcodeproj
+import XcodeProj
 import PathKit
 
 enum PBXFilePathError: String, Error {


### PR DESCRIPTION
This allows Shark to work with `.xcodeproj` files that fetch Swift Packages.