### PR TITLE
Fix regex interpolation search for emoji strings

### DIFF
--- a/Sources/Shark/LocalizationEnumBuilder.swift
+++ b/Sources/Shark/LocalizationEnumBuilder.swift
@@ -81,8 +81,8 @@ private enum LocalizationValue: Comparable {
     
     private static func interpolationTypes(forValue value: String) throws -> [InterpolationType] {
         let regex = try NSRegularExpression(pattern: "%([0-9]*.[0-9]*(d|i|u|f|ld)|(\\d\\$)?@|d|i|u|f|ld)", options: [])
-        
-        let results = regex.matches(in: value, options: [], range: NSRange(location: 0, length: value.count))
+
+        let results = regex.matches(in: value, options: [], range: NSRange(location: 0, length: value.utf16.count))
         return results.map { (value as NSString).substring(with: $0.range) }.map(InterpolationType.init)
     }
 }


### PR DESCRIPTION
We weren't correctly scanning to the end when there were unicode characters with width > 1. 